### PR TITLE
Add scoring for level exits

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def main():
     # Create toolbar and level
     toolbar = SkillToolbar()
     # Assume you have a map text file called 'level1_map.txt' in the same folder
-    level = Level("level1_map.txt", SCREEN_WIDTH, SCREEN_HEIGHT)
+    level = Level("level1_map.txt", SCREEN_WIDTH, SCREEN_HEIGHT, target_exits=5)
 
     running = True
     while running:
@@ -34,6 +34,9 @@ def main():
 
         # Update game logic
         level.update()
+        pygame.display.set_caption(
+            f"PixelPioneers - Exits: {level.exit_count}/{level.target_exits} "
+            f"Score: {int(level.get_score())}")
 
         # Draw everything
         screen.fill((0, 0, 0))


### PR DESCRIPTION
## Summary
- count how many lemmings exit a level
- track time and compute a simple score
- display exits and score in the window caption

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684c3e0655548322be70b4a8e1e7bf78